### PR TITLE
Add MariaDB user if provided.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,11 @@ EXPOSE 3306
 
 # start servers
 ADD startServers.sh /usr/sbin/start-servers
+ADD setupMysqlUser.sh /usr/sbin/setup-mysql-user
 ENV START_APACHE true
 ENV APACHE_ENABLE_PORT_80 false
 ENV START_MYSQL true
 ENV START_POSTGRESQL false
 ENV ENABLE_DAV false
 ENV ENABLE_CRON true
-CMD start-servers; sleep infinity
+CMD start-servers; setup-mysql-user; sleep infinity

--- a/setupMysqlUser.sh
+++ b/setupMysqlUser.sh
@@ -17,7 +17,7 @@ if [ "$MYSQL_USER" ] && [ "$MYSQL_PASSWORD" ]; then
         echo "Adding user $MYSQL_USER "
         waitForMysql
         mysql -u root -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';"
-        mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%';"
+        mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%' WITH GRANT OPTION;"
         mysql -u root -e "FLUSH PRIVILEGES;"        
         echo "Done."
     fi

--- a/setupMysqlUser.sh
+++ b/setupMysqlUser.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+function waitForMysql {
+    while [[ $(mysqladmin ping --silent) != "mysqld is alive" ]]; do
+        printf .
+        lf=$'\n'
+        sleep 1
+    done
+    printf "$lf"
+}
+
+# Add user for mariaDB at startup
+if [ "$MYSQL_USER" ] && [ "$MYSQL_PASSWORD" ]; then
+    if [ -e ~/mysql_user_added ]; then
+        echo "User already added."
+    else
+        echo "Adding user $MYSQL_USER "
+        waitForMysql
+        mysql -u root -e "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD';"
+        mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$MYSQL_USER'@'%';"
+        mysql -u root -e "FLUSH PRIVILEGES;"        
+        echo "Done."
+    fi
+    touch ~/mysql_user_added
+fi


### PR DESCRIPTION
Hi Grey

Thanks for your LAMP docker image. I've added the possibility to add a mariaDB user. If the env variables are set the user is added and it is possible to connect to the db by any client from outside of the container.

What do you think about it? I am not sure if the code really deserves to be in a separate file. I would move it if you think it should be in startServers.sh.

Greetings
Roman